### PR TITLE
Allow defining many tags per service

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -23,11 +23,11 @@ class Container {
    * @param {String} name
    * @param {Scalar|Function} value
    * @param {Array} dependencies
-   * @param {String} tag
+   * @param {String|String[]} tags
    */
-  register(name, value, dependencies = [], tag = null) {
+  register(name, value, dependencies = [], tags = []) {
     if (Container.isConstructor(value)) {
-      this.registerDefinition(name, value, dependencies, tag);
+      this.registerDefinition(name, value, dependencies, tags);
     } else {
       this.registerParameter(name, value);
     }
@@ -39,11 +39,12 @@ class Container {
    * @param {String} name
    * @param {Function} classname
    * @param {Array} dependencies
-   * @param {String} tag
+   * @param {String|String[]} tags
    */
-  registerDefinition(name, classname, dependencies = [], tag = null) {
+  registerDefinition(name, classname, dependencies = [], tags = []) {
+    tags = typeof (tags) === 'string' ? [tags] : tags;
     this.ensureUniqueness(name);
-    this.services.set(name, { classname, name, dependencies, tag });
+    this.services.set(name, { classname, name, dependencies, tags });
   }
 
   /**
@@ -98,16 +99,16 @@ class Container {
   }
 
   /**
-   * Get tagged service
+   * Get services for a given tag.
    *
    * @param {String} tag
    *
    * @return {Array}
    */
-  getTaggedService(tag) {
+  getTaggedServices(tag) {
     return Array
       .from(this.services.values())
-      .filter(definition => definition.tag === tag)
+      .filter(definition => definition.tags.includes(tag))
     ;
   }
 

--- a/test/Container.spec.js
+++ b/test/Container.spec.js
@@ -3,7 +3,9 @@ import Container from '../src/Container';
 describe('Container', () => {
     const container = new Container();
     class MyClass { }
-    container.registerDefinition('my:class', MyClass);
+    class BarClass { }
+    container.registerDefinition('my:class', MyClass, [], ['foo_tag']);
+    container.registerDefinition('bar', BarClass, [], ['foo_tag', 'bar_tag']);
 
     describe('Container.get()', () => {
         test('should return the expected service when asked for', () => {
@@ -14,6 +16,22 @@ describe('Container', () => {
             expect(() => {
                 container.get('unexisting:service');
             }).toThrowError('Service or parameter "unexisting:service" not found.');
+        });
+    });
+
+    describe('Container.getTaggedServices()', () => {
+        test('should return all services with a given tag', () => {
+            expect(container.getTaggedServices('foo_tag')).toEqual([
+                { classname: MyClass, dependencies: [], name: 'my:class', tags: ['foo_tag'] },
+                { classname: BarClass, dependencies: [], name: 'bar', tags: ['foo_tag', 'bar_tag'] }
+            ]);
+            expect(container.getTaggedServices('bar_tag')).toEqual([
+                { classname: BarClass, dependencies: [], name: 'bar', tags: ['foo_tag', 'bar_tag'] }
+            ]);
+        });
+
+        test('should return an empty array on undefined tag', () => {
+            expect(container.getTaggedServices('foobar')).toEqual([]);
         });
     });
 });


### PR DESCRIPTION
For e.g. a `logger.foo_channel` +`listener.stream_closed` tagged service