### PR TITLE
Fix constructor typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Given the given class, you want to declare as a service:
 export default class MyApiClient {
     constructor(host, key) {
         this.host = host;
-        this.key keyhost;
+        this.key = key;
     }
 
     login() {


### PR DESCRIPTION
I think there is a typo in the readme with the given class constructor